### PR TITLE
[FEAT] 인터뷰 생성 

### DIFF
--- a/Api/src/main/java/com/catchyou/api/config/security/SecurityConfig.java
+++ b/Api/src/main/java/com/catchyou/api/config/security/SecurityConfig.java
@@ -63,10 +63,11 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher(API_PREFIX + "/auth/login/reissue"))
                                 .permitAll()
                         .requestMatchers(
-                                new AntPathRequestMatcher(API_PREFIX + "/criminal/**")
+                                new AntPathRequestMatcher(API_PREFIX + "/criminal/police/**")
                         ).hasRole(String.valueOf(POLICE))
                         .requestMatchers(
-                                new AntPathRequestMatcher(API_PREFIX + "/criminal/confirm-code/**")
+                                new AntPathRequestMatcher(API_PREFIX + "/criminal/director/**"),
+                                new AntPathRequestMatcher(API_PREFIX + "/interview/**")
                         ).hasRole(String.valueOf(DIRECTER))
                         .anyRequest().authenticated());
 

--- a/Api/src/main/java/com/catchyou/api/criminal/controller/CriminalController.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/controller/CriminalController.java
@@ -18,29 +18,29 @@ public class CriminalController {
     private final CriminalService criminalService;
 
     //경찰이 자신이 등록한 사건만 상세 조회
-    @GetMapping("/{criminalId}")
+    @GetMapping("/police/{criminalId}")
     public MyCriminalDetailsDto getCriminalDetails(@PathVariable Long criminalId) {
         return criminalService.getCriminalDetails(criminalId);
     }
 
     //경찰이 자신이 등록한 사건만 목록 조회
-    @GetMapping("/myList")
+    @GetMapping("/police/myList")
     public MyCriminalListResponse getCriminalList(){
         return criminalService.getCriminalList();
     }
 
-    @PostMapping
+    @PostMapping("/police")
     public BaseResponse<Long> createCriminal(@RequestBody @Valid CreateCriminalRequest request) {
         return criminalService.createCriminal(request);
     }
 
-    @PutMapping("/{criminalId}")
+    @PutMapping("/police/{criminalId}")
     public BaseResponse<Long> updateCriminal(@PathVariable Long criminalId,
                                              @RequestBody @Valid UpdateCriminalRequest request){
         return criminalService.updateCriminal(criminalId, request);
     }
 
-    @PostMapping("/confirm-code/{criminalCode}")
+    @PostMapping("/director/confirm-code/{criminalCode}")
     public BaseResponse<Long> confirmCode(@PathVariable String criminalCode){
         return criminalService.confirmCriminalCode(criminalCode);
     }

--- a/Api/src/main/java/com/catchyou/api/criminal/service/CriminalService.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/service/CriminalService.java
@@ -67,7 +67,7 @@ public class CriminalService {
 
         String criminalCode = createCriminalCode(criminal.getId());
         criminal.updateCriminalCode(criminalCode);
-        criminalRepository.save(criminal);
+        criminalAdaptor.save(criminal);
         return BaseResponse.of("사건 등록되었습니다.", criminal.getId());
     }
 

--- a/Api/src/main/java/com/catchyou/api/interview/controller/InterviewController.java
+++ b/Api/src/main/java/com/catchyou/api/interview/controller/InterviewController.java
@@ -1,0 +1,21 @@
+package com.catchyou.api.interview.controller;
+
+import com.catchyou.api.interview.service.InterviewService;
+import com.catchyou.core.dto.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/interview")
+public class InterviewController {
+    private final InterviewService interviewService;
+
+    @PostMapping("/{criminalId}")
+    public BaseResponse<Long> createInterview(@PathVariable Long criminalId){
+        return interviewService.createInterview(criminalId);
+    }
+}

--- a/Api/src/main/java/com/catchyou/api/interview/service/InterviewService.java
+++ b/Api/src/main/java/com/catchyou/api/interview/service/InterviewService.java
@@ -1,0 +1,48 @@
+package com.catchyou.api.interview.service;
+
+import com.catchyou.api.config.security.UserUtils;
+import com.catchyou.core.dto.BaseResponse;
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.criminal.adaptor.CriminalAdaptor;
+import com.catchyou.domain.criminal.entity.Criminal;
+import com.catchyou.domain.criminal.validator.CriminalValidator;
+import com.catchyou.domain.interview.adaptor.InterviewAdaptor;
+import com.catchyou.domain.interview.entity.Interview;
+import com.catchyou.domain.user.adaptor.UserAdaptor;
+import com.catchyou.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class InterviewService {
+    private final UserUtils userHelper;
+    private final UserAdaptor userAdaptor;
+    private final CriminalAdaptor criminalAdaptor;
+    private final CriminalValidator criminalValidator;
+    private final InterviewAdaptor interviewAdaptor;
+
+    public BaseResponse<Long> createInterview(Long criminalId){
+        User currentUser = userHelper.getCurrentUser();
+        Criminal criminal = criminalAdaptor.findById(criminalId);
+
+        //해당 사건의 몽타주 제작자인지 확인
+        criminalValidator.isValidCriminalDirector(criminal, currentUser);
+
+        //이미 확정된 몽타주가 있는지 확인
+        criminalValidator.isValidCreateMontage(criminal);
+
+        Interview interview = interviewAdaptor.save(
+                Interview.builder()
+                .criminal(criminal)
+                .selectStatus(Status.N)
+                .selected(Status.N)
+                .build()
+        );
+        return BaseResponse.of("인터뷰 생성되었습니다.", interview.getId());
+    }
+}

--- a/Domain/src/main/java/com/catchyou/domain/criminal/entity/Criminal.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/entity/Criminal.java
@@ -64,7 +64,8 @@ public class Criminal extends BaseTimeEntity {
     public void updateCriminalCode(String criminalCode){
         this.criminalCode = criminalCode;
     }
-    public void updateSelectStatus(){   //완료 상태를 Y로 업데이트
+
+    private void updateSelectStatus(){   //완료 상태를 Y로 업데이트
         this.selectStatus = Status.Y;
     }
 

--- a/Domain/src/main/java/com/catchyou/domain/criminal/exception/CriminalErrorCode.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/exception/CriminalErrorCode.java
@@ -28,7 +28,11 @@ public enum CriminalErrorCode implements BaseErrorCode {
     @ExplainError("존재하지 않는 사건 코드로 조회 시 발생하는 오류입니다.")
     NOT_FOUND_CRIMINAL_CODE(NOT_FOUND, "Criminal-404-4", "존재하지 않는 사건 코드입니다."),
     @ExplainError("해당 사건에 이미 몽타주 제작자가 존재하는 경우 발생하는 오류입니다.")
-    CANNOT_REGISTER_TO_CRIMINAL(BAD_REQUEST, "Criminal-400-3", "이미 몽타주 제작자가 존재하는 사건입니다.");
+    CANNOT_REGISTER_TO_CRIMINAL(BAD_REQUEST, "Criminal-400-3", "이미 몽타주 제작자가 존재하는 사건입니다."),
+    @ExplainError("해당 사건에 권한이 없는 몽타주 제작자가 접근하려 할 시 발생하는 오류입니다.")
+    NOT_VALID_CRIMINAL_DIRECTOR(BAD_REQUEST, "Criminal-400-4", "해당 유저가 몽타주를 제작할 수 있는 사건이 아닙니다."),
+    @ExplainError("해당 사건에 대해 이미 확정된 몽타주가 있을 경우 발생하는 오류입니다.")
+    CANNOT_CREATE_MONTAGE(BAD_REQUEST, "Criminal-400-5", "이미 확정된 몽타주가 존재하는 사건입니다.");
 
     private final Integer statusCode;
     private final String errorCode;

--- a/Domain/src/main/java/com/catchyou/domain/criminal/validator/CriminalValidator.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/validator/CriminalValidator.java
@@ -2,6 +2,7 @@ package com.catchyou.domain.criminal.validator;
 
 import com.catchyou.core.annotation.Validator;
 import com.catchyou.core.exception.BaseException;
+import com.catchyou.domain.common.Status;
 import com.catchyou.domain.criminal.adaptor.CriminalAdaptor;
 import com.catchyou.domain.criminal.entity.Criminal;
 import com.catchyou.domain.user.entity.User;
@@ -9,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Objects;
 
-import static com.catchyou.domain.criminal.exception.CriminalErrorCode.NOT_VALID_CRIMINAL_USER;
+import static com.catchyou.domain.criminal.exception.CriminalErrorCode.*;
 
 @Validator
 @RequiredArgsConstructor
@@ -24,5 +25,15 @@ public class CriminalValidator {
     //이미 등록된 몽타주 제작자가 있는지 확인
     public boolean alreadyExistDirector(Criminal criminal){
         return criminal.getDirector() != null;
+    }
+
+    public void isValidCriminalDirector(Criminal criminal, User director){
+        if(!Objects.equals(criminal.getDirector(), director))
+            throw new BaseException(NOT_VALID_CRIMINAL_DIRECTOR);
+    }
+
+    public void isValidCreateMontage(Criminal criminal){
+        if(criminal.getSelectStatus().equals(Status.Y))
+            throw new BaseException(CANNOT_CREATE_MONTAGE);
     }
 }

--- a/Domain/src/main/java/com/catchyou/domain/interview/adaptor/InterviewAdaptor.java
+++ b/Domain/src/main/java/com/catchyou/domain/interview/adaptor/InterviewAdaptor.java
@@ -1,0 +1,38 @@
+package com.catchyou.domain.interview.adaptor;
+
+import com.catchyou.core.annotation.Adaptor;
+import com.catchyou.core.exception.BaseException;
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.criminal.entity.Criminal;
+import com.catchyou.domain.interview.entity.Interview;
+import com.catchyou.domain.interview.repository.InterviewRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.catchyou.domain.interview.exception.InterviewErrorCode.NOT_FOUND_INTERVIEW;
+import static com.catchyou.domain.interview.exception.InterviewErrorCode.NOT_FOUND_SELECTED_INTERVIEW;
+
+@Adaptor
+@RequiredArgsConstructor
+public class InterviewAdaptor {
+    private final InterviewRepository interviewRepository;
+
+    public Interview save(Interview interview){
+        return interviewRepository.save(interview);
+    }
+
+    public Interview findById(Long id){
+        return interviewRepository.findById(id)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_INTERVIEW));
+    }
+
+    public List<Interview> findByCriminal(Criminal criminal){
+        return interviewRepository.findAllByCriminal(criminal);
+    }
+
+    public Interview findSelectedInterview(Criminal criminal){
+        return interviewRepository.findByCriminalAndSelected(criminal, Status.Y)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_SELECTED_INTERVIEW));
+    }
+}

--- a/Domain/src/main/java/com/catchyou/domain/interview/entity/Interview.java
+++ b/Domain/src/main/java/com/catchyou/domain/interview/entity/Interview.java
@@ -1,0 +1,40 @@
+package com.catchyou.domain.interview.entity;
+
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.criminal.entity.Criminal;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "Interview")
+public class Interview {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interview_id")
+    private Long id;    //인터뷰 값
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "criminal_id", referencedColumnName = "id")
+    private Criminal criminal;
+
+    @Enumerated(EnumType.STRING)
+    private Status selectStatus;    //해당 인터뷰에 대해 선택된 몽타주 있는지
+
+    @Enumerated(EnumType.STRING)
+    private Status selected;    //선택된 인터뷰인지
+
+    public void updateSelectStatus(){
+        this.selectStatus = Status.Y;
+    }
+
+    public void updateSelected(){
+        this.selected = Status.Y;
+    }
+}

--- a/Domain/src/main/java/com/catchyou/domain/interview/exception/InterviewErrorCode.java
+++ b/Domain/src/main/java/com/catchyou/domain/interview/exception/InterviewErrorCode.java
@@ -1,0 +1,39 @@
+package com.catchyou.domain.interview.exception;
+
+import com.catchyou.core.annotation.ExplainError;
+import com.catchyou.core.dto.ErrorDetail;
+import com.catchyou.core.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import static com.catchyou.core.consts.CatchyouStatic.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum InterviewErrorCode implements BaseErrorCode {
+    @ExplainError("인터뷰 조회 시 존재하지 않는 인터뷰일 경우 발생하는 오류입니다.")
+    NOT_FOUND_INTERVIEW(NOT_FOUND, "Interview-404-1", "존재하지 않는 인터뷰입니다."),
+    @ExplainError("사건에 대해 선택된 인터뷰가 없는 경우 발생하는 오류입니다.")
+    NOT_FOUND_SELECTED_INTERVIEW(NOT_FOUND, "Interview-404-2", "사건에 대해 선택된 인터뷰가 없습니다.");
+
+
+    private final Integer statusCode;
+    private final String errorCode;
+    private final String reason;
+
+    @Override
+    public ErrorDetail getErrorDetail() {
+        return ErrorDetail.of(statusCode, errorCode, reason);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+
+}

--- a/Domain/src/main/java/com/catchyou/domain/interview/repository/InterviewRepository.java
+++ b/Domain/src/main/java/com/catchyou/domain/interview/repository/InterviewRepository.java
@@ -1,0 +1,19 @@
+package com.catchyou.domain.interview.repository;
+
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.criminal.entity.Criminal;
+import com.catchyou.domain.interview.entity.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+    Optional<Interview> findById(Long id);
+
+    List<Interview> findAllByCriminal(Criminal criminal);
+
+    Optional<Interview> findByCriminalAndSelected(Criminal criminal, Status selected);
+}

--- a/Domain/src/main/java/com/catchyou/domain/montage/adaptor/MontageAdaptor.java
+++ b/Domain/src/main/java/com/catchyou/domain/montage/adaptor/MontageAdaptor.java
@@ -1,0 +1,38 @@
+package com.catchyou.domain.montage.adaptor;
+
+import com.catchyou.core.annotation.Adaptor;
+import com.catchyou.core.exception.BaseException;
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.interview.entity.Interview;
+import com.catchyou.domain.montage.entity.Montage;
+import com.catchyou.domain.montage.repository.MontageRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.catchyou.domain.montage.exception.MontageErrorCode.NOT_FOUND_MONTAGE;
+import static com.catchyou.domain.montage.exception.MontageErrorCode.NOT_FOUND_SELECTED_MONTAGE;
+
+@Adaptor
+@RequiredArgsConstructor
+public class MontageAdaptor {
+    private final MontageRepository montageRepository;
+
+    public Montage save(Montage montage) {
+        return montageRepository.save(montage);
+    }
+
+    public Montage findById(Long id){
+        return montageRepository.findById(id)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_MONTAGE));
+    }
+
+    public List<Montage> findByInterview(Interview interview){
+        return montageRepository.findAllByInterview(interview);
+    }
+
+    public Montage findSelectedMontage(Interview interview){
+        return montageRepository.findByInterviewAndSelected(interview, Status.Y)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_SELECTED_MONTAGE));
+    }
+}

--- a/Domain/src/main/java/com/catchyou/domain/montage/entity/Montage.java
+++ b/Domain/src/main/java/com/catchyou/domain/montage/entity/Montage.java
@@ -1,0 +1,30 @@
+package com.catchyou.domain.montage.entity;
+
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.interview.entity.Interview;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "Montage")
+public class Montage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "montage_id")
+    private Long id;    //파일명과 같음
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "interview_id", referencedColumnName = "id")
+    private Interview interview;
+
+    @Enumerated(EnumType.STRING)
+    private Status selected;    //선택된 몽타주인지
+
+    public void updateSelected(){
+        this.selected = Status.Y;
+    }
+}

--- a/Domain/src/main/java/com/catchyou/domain/montage/exception/MontageErrorCode.java
+++ b/Domain/src/main/java/com/catchyou/domain/montage/exception/MontageErrorCode.java
@@ -1,0 +1,39 @@
+package com.catchyou.domain.montage.exception;
+
+import com.catchyou.core.annotation.ExplainError;
+import com.catchyou.core.dto.ErrorDetail;
+import com.catchyou.core.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import static com.catchyou.core.consts.CatchyouStatic.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum MontageErrorCode implements BaseErrorCode {
+    @ExplainError("몽타주 조회 시 존재하지 않는 몽타주일 경우 발생하는 오류입니다.")
+    NOT_FOUND_MONTAGE(NOT_FOUND, "Montage-404-1", "존재하지 않는 몽타주입니다."),
+    @ExplainError("인터뷰에 대해 선택된 몽타주가 없는 경우 발생하는 오류입니다.")
+    NOT_FOUND_SELECTED_MONTAGE(NOT_FOUND, "Montage-404-2", "인터뷰에 대해 선택된 몽타주가 없습니다.");
+
+
+    private final Integer statusCode;
+    private final String errorCode;
+    private final String reason;
+
+    @Override
+    public ErrorDetail getErrorDetail() {
+        return ErrorDetail.of(statusCode, errorCode, reason);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+
+}

--- a/Domain/src/main/java/com/catchyou/domain/montage/repository/MontageRepository.java
+++ b/Domain/src/main/java/com/catchyou/domain/montage/repository/MontageRepository.java
@@ -1,0 +1,18 @@
+package com.catchyou.domain.montage.repository;
+
+import com.catchyou.domain.common.Status;
+import com.catchyou.domain.interview.entity.Interview;
+import com.catchyou.domain.montage.entity.Montage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MontageRepository extends JpaRepository<Montage, Long> {
+    Optional<Montage> findById(Long id);
+    Optional<Montage> findByInterviewAndSelected(Interview interview, Status selected);
+
+    List<Montage> findAllByInterview(Interview interview);
+}


### PR DESCRIPTION
## 📌 관련 이슈

closed #19 

## ✨ 작업 내용

몽타주 제작 과정을 한 묶음으로 구분할 수 있도록 인터뷰 entity로 정의하여 구현함.
몽타주 제작 과정 시작 전에 인터뷰 생성 api를 호출함으로써 생성, 재정의, 선택 시 인터뷰를 통해 구분할 수 있게 됨.

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
