### PR TITLE
[FEAT] 몽타주 제작자 사건 리스트 조회

### DIFF
--- a/Api/src/main/java/com/catchyou/api/criminal/controller/CriminalController.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/controller/CriminalController.java
@@ -1,9 +1,6 @@
 package com.catchyou.api.criminal.controller;
 
-import com.catchyou.api.criminal.dto.CreateCriminalRequest;
-import com.catchyou.api.criminal.dto.MyCriminalDetailsDto;
-import com.catchyou.api.criminal.dto.MyCriminalListResponse;
-import com.catchyou.api.criminal.dto.UpdateCriminalRequest;
+import com.catchyou.api.criminal.dto.*;
 import com.catchyou.api.criminal.service.CriminalService;
 import com.catchyou.api.signup.dto.SignupRequest;
 import com.catchyou.core.dto.BaseResponse;
@@ -43,6 +40,12 @@ public class CriminalController {
     @PostMapping("/director/confirm-code/{criminalCode}")
     public BaseResponse<Long> confirmCode(@PathVariable String criminalCode){
         return criminalService.confirmCriminalCode(criminalCode);
+    }
+
+    //제작자가 권한부여받은 사건만 목록 조회
+    @GetMapping("/director/myList")
+    public DirectorCriminalListResponse getDirectorCriminalList(){
+        return criminalService.getDirectorCriminalList();
     }
 
 }

--- a/Api/src/main/java/com/catchyou/api/criminal/dto/DirectorCriminalListResponse.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/dto/DirectorCriminalListResponse.java
@@ -1,0 +1,21 @@
+package com.catchyou.api.criminal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DirectorCriminalListResponse {
+    List<MyCriminalListDto> criminalListDtos;
+    List<MyCriminalListDto> confirmedCriminalListDtos;
+
+    public static DirectorCriminalListResponse from(List<MyCriminalListDto> criminalListDtos,
+                                                    List<MyCriminalListDto> confirmedCriminalListDtos){
+        return DirectorCriminalListResponse.builder()
+                .criminalListDtos(criminalListDtos)
+                .confirmedCriminalListDtos(confirmedCriminalListDtos)
+                .build();
+    }
+}

--- a/Domain/src/main/java/com/catchyou/domain/criminal/adaptor/CriminalAdaptor.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/adaptor/CriminalAdaptor.java
@@ -29,6 +29,10 @@ public class CriminalAdaptor {
         return criminalRepository.findAllByUser(user);
     }
 
+    public List<Criminal> findByDirector(User director){
+        return criminalRepository.findAllByDirector(director);
+    }
+
     public Criminal findByCriminalCode(String criminalCode) {
         return criminalRepository.findByCriminalCode(criminalCode)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_CRIMINAL_CODE));

--- a/Domain/src/main/java/com/catchyou/domain/criminal/repository/CriminalRepository.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/repository/CriminalRepository.java
@@ -17,4 +17,6 @@ public interface CriminalRepository extends JpaRepository<Criminal, Long> {
     List<Criminal> findAllByUser(User user);
 
     Optional<Criminal> findByCriminalCode(String criminalCode);
+
+    List<Criminal> findAllByDirector(User director);
 }


### PR DESCRIPTION
## 📌 관련 이슈

closed #32 

## ✨ 작업 내용
- 몽타주 제작자의 사건 리스트를 확정된 사건/확정되지 않은 사건으로 조회하도록 구현함
- 기존 경찰의 사건 리스트를 사건 등록일 역순으로 정렬함


## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
