### PR TITLE
[REFACTOR] 몽타주 및 제작자 조회되도록 수정

### DIFF
--- a/Api/src/main/java/com/catchyou/api/criminal/dto/MyCriminalDetailsDto.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/dto/MyCriminalDetailsDto.java
@@ -4,6 +4,7 @@ import com.catchyou.domain.common.Status;
 import com.catchyou.domain.criminal.entity.Criminal;
 import com.catchyou.domain.criminal.enums.CrimeType;
 import com.catchyou.domain.criminal.enums.Region;
+import com.catchyou.domain.montage.entity.Montage;
 import com.catchyou.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -17,6 +18,8 @@ public class MyCriminalDetailsDto {
     private Long id;    //사건 id
 
     private Long userId;  //작성자(경찰) 아이디
+
+    private String userName;
 
     private String title;   //제목
 
@@ -39,11 +42,17 @@ public class MyCriminalDetailsDto {
     private LocalDateTime updatedAt;
 
     //여기에 몽타주 이미지, 몽타주 작성자 추가
+    private Long montageId;
 
-    public static MyCriminalDetailsDto of(Criminal criminal){
+    private Long directorId;
+
+    private String directorName;
+
+    public static MyCriminalDetailsDto of(Criminal criminal, Montage montage){
         return MyCriminalDetailsDto.builder()
                 .id(criminal.getId())
                 .userId(criminal.getUser().getId())
+                .userName(criminal.getUser().getName())
                 .title(criminal.getTitle())
                 .summary(criminal.getSummary())
                 .description(criminal.getDescription())
@@ -54,6 +63,9 @@ public class MyCriminalDetailsDto {
                 .selectStatus(criminal.getSelectStatus())
                 .createdAt(criminal.getCreatedAt())
                 .updatedAt(criminal.getUpdatedAt())
+                .montageId(montage.getId())
+                .directorId(criminal.getDirector().getId())
+                .directorName(criminal.getDirector().getName())
                 .build();
     }
 }

--- a/Api/src/main/java/com/catchyou/api/criminal/dto/MyCriminalListDto.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/dto/MyCriminalListDto.java
@@ -16,6 +16,8 @@ public class MyCriminalListDto {
 
     private Long userId;
 
+    private String userName;
+
     private String title;   //제목
 
     private CrimeType crimeType;    //사건 종류
@@ -27,6 +29,7 @@ public class MyCriminalListDto {
     public static MyCriminalListDto of(Criminal criminal){
         return MyCriminalListDto.builder()
                 .id(criminal.getId())
+                .userName(criminal.getUser().getName())
                 .userId(criminal.getUser().getId())
                 .title(criminal.getTitle())
                 .crimeType(criminal.getCrimeType())


### PR DESCRIPTION
## 📌 관련 이슈

closed #34 

## ✨ 작업 내용

- 제작자가 연결될 경우 사건 관련 조회시 제작자 확인가능하도록 수정
- 몽타주가 확정되었을 경우 사건 관련 조회시 몽타주 아이디 확인가능하도록 수정
- 경찰과 몽타주 제작자가 사건 상세 조회할 경우 서로의 실명 확인가능하도록 수정
- 몽타주 제작자 사건 상세 조회시 확정된 몽타주가 있다면 선택된 몽타주 리스트는 볼 수 없도록 수정

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
