### PR TITLE
[FEAT] 일반 유저들 공개 사건 리스트 조회 

### DIFF
--- a/Api/src/main/java/com/catchyou/api/config/security/SecurityConfig.java
+++ b/Api/src/main/java/com/catchyou/api/config/security/SecurityConfig.java
@@ -59,8 +59,9 @@ public class SecurityConfig {
                 authorizeRequests.requestMatchers(
                                 new AntPathRequestMatcher(API_PREFIX + "/auth/login"),
                                         new AntPathRequestMatcher(API_PREFIX + "/signup/**"),
-                                new AntPathRequestMatcher(API_PREFIX + "/auth/login/reissue"))
-                                .permitAll()
+                                new AntPathRequestMatcher(API_PREFIX + "/auth/login/reissue"),
+                                new AntPathRequestMatcher(API_PREFIX + "/criminal/open/**")
+                        ).permitAll()
                         .requestMatchers(
                                 new AntPathRequestMatcher(API_PREFIX + "/criminal/police/**")
                         ).hasRole(String.valueOf(POLICE))

--- a/Api/src/main/java/com/catchyou/api/criminal/controller/CriminalController.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/controller/CriminalController.java
@@ -61,4 +61,10 @@ public class CriminalController {
                                                     @RequestBody SelectInterviewMontageRequest request){
         return criminalService.selectCriminalMontage(criminalId, request);
     }
+
+    //일반 유저(미로그인)들이 공개된 사건 리스트 조회
+    @GetMapping("/open")
+    public OpenCriminalListResponse getOpenCriminalList(){
+        return criminalService.getOpenCriminalList();
+    }
 }

--- a/Api/src/main/java/com/catchyou/api/criminal/dto/OpenCriminalListDto.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/dto/OpenCriminalListDto.java
@@ -1,0 +1,38 @@
+package com.catchyou.api.criminal.dto;
+
+import com.catchyou.domain.criminal.entity.Criminal;
+import com.catchyou.domain.criminal.enums.CrimeType;
+import com.catchyou.domain.criminal.enums.Region;
+import com.catchyou.domain.montage.entity.Montage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OpenCriminalListDto {
+    private Long id;
+
+    private Long userId;
+
+    private String userName;
+
+    private String title;
+
+    private CrimeType crimeType;
+
+    private Region region;
+
+    private Long montageId;
+
+    public static OpenCriminalListDto of(Criminal criminal, Montage montage){
+        return OpenCriminalListDto.builder()
+                .id(criminal.getId())
+                .userId(criminal.getUser().getId())
+                .userName(criminal.getUser().getName())
+                .title(criminal.getTitle())
+                .crimeType(criminal.getCrimeType())
+                .region(criminal.getRegion())
+                .montageId(montage.getId())
+                .build();
+    }
+}

--- a/Api/src/main/java/com/catchyou/api/criminal/dto/OpenCriminalListResponse.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/dto/OpenCriminalListResponse.java
@@ -1,0 +1,18 @@
+package com.catchyou.api.criminal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OpenCriminalListResponse {
+    List<OpenCriminalListDto> openCriminalListDtos;
+
+    public static OpenCriminalListResponse from(List<OpenCriminalListDto> openCriminalListDtos){
+        return OpenCriminalListResponse.builder()
+                .openCriminalListDtos(openCriminalListDtos)
+                .build();
+    }
+}

--- a/Api/src/main/java/com/catchyou/api/criminal/service/CriminalService.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/service/CriminalService.java
@@ -180,6 +180,23 @@ public class CriminalService {
         return BaseResponse.of("선택한 몽타주가 확정되었습니다.", criminalId);
     }
 
+    //일반 유저들이 공개 몽타주 리스트 볼 수 있게 함
+    public OpenCriminalListResponse getOpenCriminalList(){
+
+        //공개된 사건에 대해 dto 리스트 생성
+        List<OpenCriminalListDto> openCriminalListDtos = criminalAdaptor.findByStatus()
+                .stream()
+                .map(criminal -> {
+                    Interview interview = interviewAdaptor.findSelectedInterview(criminal);
+                    Montage montage = montageAdaptor.findSelectedMontage(interview);
+                    return OpenCriminalListDto.of(criminal, montage);
+                })
+                .collect(Collectors.toList());
+
+        return OpenCriminalListResponse.from(openCriminalListDtos);
+    }
+
+
     private MyCriminalDetailsDto getCriminalDetailsDto(Criminal criminal){
         if(criminal.getSelectStatus().equals(Status.N))
              return MyCriminalDetailsDto.of(criminal, null);

--- a/Domain/src/main/java/com/catchyou/domain/criminal/adaptor/CriminalAdaptor.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/adaptor/CriminalAdaptor.java
@@ -2,6 +2,7 @@ package com.catchyou.domain.criminal.adaptor;
 
 import com.catchyou.core.annotation.Adaptor;
 import com.catchyou.core.exception.BaseException;
+import com.catchyou.domain.common.Status;
 import com.catchyou.domain.criminal.entity.Criminal;
 import com.catchyou.domain.criminal.repository.CriminalRepository;
 import com.catchyou.domain.user.entity.User;
@@ -36,6 +37,10 @@ public class CriminalAdaptor {
     public Criminal findByCriminalCode(String criminalCode) {
         return criminalRepository.findByCriminalCode(criminalCode)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_CRIMINAL_CODE));
+    }
+
+    public List<Criminal> findByStatus(){
+        return criminalRepository.findAllByStatus(Status.Y);
     }
 
 }

--- a/Domain/src/main/java/com/catchyou/domain/criminal/repository/CriminalRepository.java
+++ b/Domain/src/main/java/com/catchyou/domain/criminal/repository/CriminalRepository.java
@@ -1,5 +1,6 @@
 package com.catchyou.domain.criminal.repository;
 
+import com.catchyou.domain.common.Status;
 import com.catchyou.domain.criminal.entity.Criminal;
 import com.catchyou.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,4 +20,6 @@ public interface CriminalRepository extends JpaRepository<Criminal, Long> {
     Optional<Criminal> findByCriminalCode(String criminalCode);
 
     List<Criminal> findAllByDirector(User director);
+
+    List<Criminal> findAllByStatus(Status status);
 }


### PR DESCRIPTION
## 📌 관련 이슈

closed #40 

## ✨ 작업 내용

- 일반 유저들 공개 사건 리스트 조회 가능하도록 구현
- 일반 유저들 공개 사건 페이지에 대한 접근 권한 추가

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
