### PR TITLE
[FIX] 사건 상세 조회시 몽타주 리스트도 조회 

### DIFF
--- a/Api/src/main/java/com/catchyou/api/auth/controller/AuthResponse.java
+++ b/Api/src/main/java/com/catchyou/api/auth/controller/AuthResponse.java
@@ -1,5 +1,6 @@
 package com.catchyou.api.auth.controller;
 
+import com.catchyou.domain.user.enums.Role;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,14 +18,17 @@ public class AuthResponse {
 
     private Long accessTokenExpireDate;
 
+    private Role role;
+
     public static AuthResponse of(
-            String accessToken, String refreshToken, Long userId, Long accessTokenExpireDate
+            String accessToken, String refreshToken, Long userId, Long accessTokenExpireDate, Role role
     ){
         return AuthResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(userId)
                 .accessTokenExpireDate(accessTokenExpireDate)
+                .role(role)
                 .build();
     }
 }

--- a/Api/src/main/java/com/catchyou/api/auth/service/AuthService.java
+++ b/Api/src/main/java/com/catchyou/api/auth/service/AuthService.java
@@ -86,7 +86,8 @@ public class AuthService {
                 resolveAccessToken(user.getId(), user.getRole().getAuthority()),
                 resolveRefreshToken(user.getId()),
                 user.getId(),
-                jwtProvider.getAccessTokenTTlSecond()
+                jwtProvider.getAccessTokenTTlSecond(),
+                user.getRole()
         );
     }
 }

--- a/Api/src/main/java/com/catchyou/api/criminal/service/CriminalService.java
+++ b/Api/src/main/java/com/catchyou/api/criminal/service/CriminalService.java
@@ -143,7 +143,7 @@ public class CriminalService {
 
         MyCriminalDetailsDto criminalDetailsDto = getCriminalDetailsDto(criminal);
 
-        if(criminal.getSelectStatus().equals(Status.N))
+        if(criminal.getSelectStatus().equals(Status.Y))
             return DirectorCriminalDetailResponse.from(criminalDetailsDto, null);
 
         //확정되지 않을 사건일 경우만 필요


### PR DESCRIPTION
## 📌 관련 이슈

closed #49 

## ✨ 작업 내용

- 확정된 몽타주가 없을 시에는 몽타주 리스트가 조회되도록 수정
- 로그인 시 회원 role도 조회되도록 수정

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
